### PR TITLE
Fix queue namespace

### DIFF
--- a/queue/QueueArrayBase.cs
+++ b/queue/QueueArrayBase.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace queue
+namespace Queue
 {
     internal class QueueArrayBase
     {

--- a/queue/Run.cs
+++ b/queue/Run.cs
@@ -1,5 +1,5 @@
 using System;
-﻿namespace queue
+﻿namespace Queue
 {
     internal class Run
     {


### PR DESCRIPTION
## Summary
- use `Queue` namespace across all queue source files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840245b0aec8332a96058df66aa2ddf