### PR TITLE
Rename Clean to Clear in linked list

### DIFF
--- a/linkedList/LinkedList.cs
+++ b/linkedList/LinkedList.cs
@@ -70,9 +70,9 @@ namespace linkedList
         public int Index() => count;
 
         /// <summary>
-        /// Removes all nodes from the linked list.
+        /// Clears all nodes from the linked list.
         /// </summary>
-        public void Clean()
+        public void Clear()
         {
             head = tail = null; // Remove all references to nodes
             count = 0;         // Reset the count

--- a/linkedList/Run.cs
+++ b/linkedList/Run.cs
@@ -20,8 +20,8 @@ namespace linkedList
             Console.WriteLine("List contents:");
             linkedList.DisplayList();
 
-            linkedList.Clean();
-            Console.WriteLine("\nAfter cleaning the list:");
+            linkedList.Clear();
+            Console.WriteLine("\nAfter clearing the list:");
             linkedList.DisplayList();
         }
     }

--- a/linkedList/explain-linked-list.md
+++ b/linkedList/explain-linked-list.md
@@ -29,7 +29,7 @@ This method is used to check whether the LinkedList is empty.
 - It determines this by checking the value of Count or head.
   
 # Clear()
-this method is used to remove all nodes from the LinkedList.
+This method is used to clear all nodes from the LinkedList.
 - The head is set to null, severing all links between nodes.
 - The Count is reset to indicate an empty list.
 - Effectively, all nodes become unreachable and are garbage-collected by the runtime.


### PR DESCRIPTION
## Summary
- rename `Clean()` to `Clear()` in `LinkedList`
- update method usage in `Run.cs`
- keep documentation consistent with `Clear()`

## Testing
- `dotnet build linkedList.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840245eeb0c833294dae722e2c01f13